### PR TITLE
Added newline to end of Markdown output

### DIFF
--- a/R/bibliography.R
+++ b/R/bibliography.R
@@ -1,7 +1,7 @@
 #' Generate the bibliography
-#' @param style formatting style to print bibliography (default is plain text).  Can be 
+#' @param style formatting style to print bibliography (default is plain text).  Can be
 #' text, bibtex, html, textVersion, R, citation, or other formats
-#' defined for the print bibentry class, see ?print.bibentry for details.  
+#' defined for the print bibentry class, see ?print.bibentry for details.
 #' @param ordering a character list of the order in which information should
 #' be printed (e.g. c("author",  "year", "title", "journal", "volume",
 #' "number", "pages", "doi", "uri")) see details.  Works only for rdfa and
@@ -9,41 +9,41 @@
 #' the \code{\link{bibstyle}} method, see for more information.
 #' @param sort logical indicating if bibliography should be sorted
 #' alphabetically, defaults to FALSE
-#' @param bibtex logical, use bibtex data structure internally? 
+#' @param bibtex logical, use bibtex data structure internally?
 #' (internal option only)
-#' @param .bibstyle the bibstyle function call or string. Defaults to 
+#' @param .bibstyle the bibstyle function call or string. Defaults to
 #' journal of statistical software (JSS).  See \code{\link{bibstyle}}.
-#' @param bulleted logical.  If \code{TRUE}, for \code{style = "html"}, the 
-#' bibliography will print as a bulleted list using the \code{li} HTML tags.  
-#' @param ... additional arguments passed to print.bibentry, 
+#' @param bulleted logical.  If \code{TRUE}, for \code{style = "html"}, the
+#' bibliography will print as a bulleted list using the \code{li} HTML tags.
+#' @param ... additional arguments passed to print.bibentry,
 #' see \code{\link{bibentry}}
 #' @return a list of bibentries, providing a bibliography of what's been cited
 #' @details The markdown and rdfa print formats can take the argument
 #' `ordering`. A character string provides the order in which elements
 #' should be returned.  Elements not specified are omitted from the return
 #' entirely.  Even if both DOI or URI (usually the URL) are given, method
-#' will return the URL only if the DOI is absent/unavailable.  
-#' @examples 
+#' will return the URL only if the DOI is absent/unavailable.
+#' @examples
 #' citet(citation("knitr"))
 #' bibliography()
 #' ## use markdown formatting, show only author, year, and url
 #' bibliography("markdown", ordering = c("authors", "year", "url"))
-#' 
+#'
 #' ## Repeat citations do not create duplicates:
 #' bib <- c(citation("knitr"), citation("knitr"), citation("bibtex"),
 #'          citation("bibtex"), citation("knitr"), citation("knitcitations"),
 #'          citation("bibtex"))
 #' citep(bib)
 #' bibliography()
-#' 
+#'
 #' bibliography(style="html", bulleted = FALSE)
-#' 
+#'
 #' @export
 bibliography <-
-function (style = "markdown", .bibstyle = "JSS", ordering = c("authors", 
-    "year", "title", "journal", "volume", "number", "pages", 
-    "doi", "url"), sort = FALSE, bibtex = get("bibtex_data", 
-    envir = knitcitations_options),  bulleted = TRUE, ...) 
+function (style = "markdown", .bibstyle = "JSS", ordering = c("authors",
+    "year", "title", "journal", "volume", "number", "pages",
+    "doi", "url"), sort = FALSE, bibtex = get("bibtex_data",
+    envir = knitcitations_options),  bulleted = TRUE, ...)
 {
     out <- read_cache(bibtex = bibtex)
     if (length(out) > 0) {
@@ -52,7 +52,7 @@ function (style = "markdown", .bibstyle = "JSS", ordering = c("authors",
             out <- out[ordering]
         }
     }
-    if (style %in% c("R", "text", "bibtex", "textVersion", "citation", 
+    if (style %in% c("R", "text", "bibtex", "textVersion", "citation",
         "LaTeX")) {
         output <- print(out, style, .bibstyle = .bibstyle, ...)
     }
@@ -70,7 +70,7 @@ function (style = "markdown", .bibstyle = "JSS", ordering = c("authors",
     else if (style == "markdown") {
         output <- print_markdown(out, ordering = ordering)
         names(output) = ""
-        pretty_output <- cat(output)
+        pretty_output <- cat(paste0(output, '\n'))
     }
     else {
         stop("Style not recognized")


### PR DESCRIPTION
This hardly deserved it's own PR, but here it is anyway.

Just added a newline to end of Markdown pretty printing; the rest of the styles already include this but for Markdown there is no newline at the end of the output so the R prompt would end up in the middle of the screen after calling `bibliography()`.

The rest of the diff is just vim chomping off extra whitespace (sorry about that!)
