### PR TITLE
Fixing deprecated syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install the development version directly from Github
 
 ```r
 library(devtools)
-install_github("knitcitations", "cboettig")
+install_github("cboettig/knitcitations")
 ```
 
 Or install the current release from your CRAN mirror with `install.packages("knitcitations")`.  


### PR DESCRIPTION
The separate username parameter is deprecated in the install_github() function.  
The preferred format is now "username/repository".
