### PR TITLE
Order BibTeX entries by key

### DIFF
--- a/R/write.bibtex.R
+++ b/R/write.bibtex.R
@@ -32,7 +32,18 @@ write.bibtex <- function(entry = NULL,
   
   }
 
-  WriteBib(entry, file=file, append=append, ...)
+  keys <- vapply(
+    entry,
+    function(e) {
+      key <- e$key
+      if (is.null(key))
+        key <- NA_character_
+      key
+    },
+    character(1L)
+  )
+
+  WriteBib(entry[order(keys)], file=file, append=append, ...)
 }
 
 


### PR DESCRIPTION
This is for defining a stable-ish sort order so that a .bib file in version control doesn't change too much when adding new references.

The sorting happens in write.bibtex(), I assume that sorting won't break or change the meaning of a BibTeX file. (Duplicate keys: order() is a stable sort and won't change their order.) However, for my use case it would be sufficient to reorder in get_bib().